### PR TITLE
Fix reconcile of deleted resources in namespaced mode

### DIFF
--- a/pkg/util/lockedresourcecontroller/resource-reconciler.go
+++ b/pkg/util/lockedresourcecontroller/resource-reconciler.go
@@ -211,7 +211,10 @@ func (p *resourceModifiedPredicate) Delete(e event.DeleteEvent) bool {
 			err := p.lrr.GetClient().Get(context.TODO(), types.NamespacedName{Name: e.Object.GetNamespace()}, &namespace)
 			if err != nil {
 				p.lrr.log.Error(err, "unable to retrieve ", "namespace", "e.Meta.GetNamespace()")
-				return false
+				// If the request failed return "true" as the k8s API will deny any create/update operation in a
+				// Namespace that's marked for termination. Returning false here causes resources not being reconciled
+				// in namespaced installations (Namespace requires a client with cluster scoped permissions)
+				return true
 			}
 			if util.IsBeingDeleted(&namespace) {
 				return false


### PR DESCRIPTION
The predicate function for Delete events of the lockedresources reconciler assumes the client is a cluster scoped client with permissions to Get Namespace resources. If the call to get a Namespace fails, the deleted resources will not be reconciled. This commit fixes that by trying to reconcile the deleted resource even if the call to get the Namespace fails. This causes no problems as the k8s API will deny any create/update operation in a Namespace that's marked for termination (which was the original intention of the failing code)